### PR TITLE
feat: verify one action

### DIFF
--- a/apps/collector-page/src/components/business/task/TaskActionItem.tsx
+++ b/apps/collector-page/src/components/business/task/TaskActionItem.tsx
@@ -2,10 +2,10 @@
  * @Author: shixuewen friendlysxw@163.com
  * @Date: 2022-07-13 16:46:00
  * @LastEditors: shixuewen friendlysxw@163.com
- * @LastEditTime: 2022-08-15 13:49:12
+ * @LastEditTime: 2022-08-22 14:35:14
  * @Description: file description
  */
-import React from 'react'
+import React, { useCallback } from 'react'
 import styled from 'styled-components'
 import { ActionData, ActionType, Project, TaskType } from '../../../types/entities'
 import { UserActionStatus } from '../../../types/api'
@@ -37,13 +37,15 @@ export type TaskActionItemDataType = {
     slug: string
   }
 }
-
-export type TaskActionItemProps = {
-  data: TaskActionItemDataType
-  allowHandle?: boolean
+export type TaskActionItemHandlesType = {
   onTwitter?: (callback: () => void) => void
   onDiscord?: (callback: () => void) => void
   onFollowCommunity?: (action: TaskActionItemDataType) => void
+  onVerifyAction?: (action: TaskActionItemDataType) => void
+}
+export type TaskActionItemProps = TaskActionItemHandlesType & {
+  data: TaskActionItemDataType
+  allowHandle?: boolean
   verifying?: boolean
   copyBgc?: string
 }
@@ -54,6 +56,7 @@ const TaskActionItem: React.FC<TaskActionItemProps> = ({
   onTwitter,
   onDiscord,
   onFollowCommunity,
+  onVerifyAction,
   verifying,
   copyBgc,
 }: TaskActionItemProps) => {
@@ -92,13 +95,24 @@ const TaskActionItem: React.FC<TaskActionItemProps> = ({
         return name
     }
   }
+  const onVerifyActionClick = useCallback(() => {
+    if (onVerifyAction) {
+      onVerifyAction(data)
+    }
+  }, [])
   const renderStatus = () => {
     if (allowHandle) {
       switch (status) {
         case UserActionStatus.DONE:
           return <IconCheckboxChecked />
         case UserActionStatus.TODO:
-          return verifying ? <Loading size="1.5rem" /> : <IconCheckbox />
+          return verifying ? (
+            <Loading size="1.5rem" />
+          ) : (
+            <TaskActionStatusTodo onClick={onVerifyActionClick}>
+              <IconCheckbox />
+            </TaskActionStatusTodo>
+          )
       }
     }
     return null
@@ -123,4 +137,7 @@ const TaskActionItemWrapper = styled.div`
 
 const TaskActionContent = styled.div`
   flex: 1;
+`
+const TaskActionStatusTodo = styled.div`
+  cursor: pointer;
 `

--- a/apps/collector-page/src/components/business/task/TaskActionList.tsx
+++ b/apps/collector-page/src/components/business/task/TaskActionList.tsx
@@ -2,7 +2,7 @@
  * @Author: shixuewen friendlysxw@163.com
  * @Date: 2022-07-13 16:45:44
  * @LastEditors: shixuewen friendlysxw@163.com
- * @LastEditTime: 2022-08-12 14:52:16
+ * @LastEditTime: 2022-08-22 14:37:56
  * @Description: file description
  */
 import React from 'react'
@@ -10,7 +10,7 @@ import styled from 'styled-components'
 import ButtonBase from '../../common/button/ButtonBase'
 import Loading from '../../common/loading/Loading'
 
-import TaskActionItem, { TaskActionItemDataType } from './TaskActionItem'
+import TaskActionItem, { TaskActionItemDataType, TaskActionItemHandlesType } from './TaskActionItem'
 export type TaskActionListViewConfigType = {
   loading?: boolean
   loadingMsg?: string
@@ -25,13 +25,13 @@ export type TaskActionListViewConfigType = {
   verifyBgc?: string
 }
 export type TaskActionItemsType = TaskActionItemDataType[]
-export type TaskActionListProps = TaskActionListViewConfigType & {
-  items: TaskActionItemsType
-  onTwitter?: (callback: () => void) => void
-  onDiscord?: (callback: () => void) => void
-  onFollowCommunity?: (action: TaskActionItemDataType) => void
+export type TaskActionsListHandlesType = TaskActionItemHandlesType & {
   onVerifyActions?: () => void
 }
+export type TaskActionListProps = TaskActionListViewConfigType &
+  TaskActionsListHandlesType & {
+    items: TaskActionItemsType
+  }
 const TaskActionList: React.FC<TaskActionListProps> = ({
   items,
   loading,
@@ -42,6 +42,7 @@ const TaskActionList: React.FC<TaskActionListProps> = ({
   onDiscord,
   onFollowCommunity,
   onVerifyActions,
+  onVerifyAction,
   displayVerify,
   disabledVerify,
   loadingVerify,
@@ -77,6 +78,7 @@ const TaskActionList: React.FC<TaskActionListProps> = ({
               onDiscord={onDiscord}
               onTwitter={onTwitter}
               onFollowCommunity={onFollowCommunity}
+              onVerifyAction={onVerifyAction}
               allowHandle={allowHandle}
               copyBgc={copyBgc}
               verifying={verifyingActions.includes(item.id)}

--- a/apps/collector-page/src/components/business/task/TodoTaskItem.tsx
+++ b/apps/collector-page/src/components/business/task/TodoTaskItem.tsx
@@ -2,7 +2,7 @@
  * @Author: shixuewen friendlysxw@163.com
  * @Date: 2022-07-13 16:25:36
  * @LastEditors: shixuewen friendlysxw@163.com
- * @LastEditTime: 2022-08-17 18:11:37
+ * @LastEditTime: 2022-08-22 19:13:04
  * @Description: file description
  */
 import React, { useEffect, useRef, useState } from 'react'
@@ -14,7 +14,7 @@ import { TaskActionItemDataType } from './TaskActionItem'
 import ThumbUpAltIcon from '@mui/icons-material/ThumbUpAlt'
 import MoodIcon from '@mui/icons-material/Mood'
 import MoodBadIcon from '@mui/icons-material/MoodBad'
-import TaskActionList from './TaskActionList'
+import TaskActionList, { TaskActionsListHandlesType } from './TaskActionList'
 import { todoTaskCompleteStatusMap } from './TodoTaskList'
 import { useNavigate } from 'react-router-dom'
 
@@ -54,12 +54,10 @@ export type TodoTaskItemDataViewType = {
   viewConfig?: TodoTaskItemViewConfigType
 }
 
-export type TodoTaskItemHandlesType = {
+export type TodoTaskItemHandlesType = TaskActionsListHandlesType & {
   onMint?: (task: TodoTaskItemDataType) => void
-  onRefreshTask?: (task: TodoTaskItemDataType) => void
-  onTwitter?: (callback: () => void) => void
-  onDiscord?: (callback: () => void) => void
-  onFollowCommunity?: (action: TaskActionItemDataType) => void
+  onVerifyTask?: (task: TodoTaskItemDataType) => void
+  onVerifyAction?: (action: TaskActionItemDataType) => void
 }
 
 export type TodoTaskItemProps = TodoTaskItemDataViewType & TodoTaskItemHandlesType
@@ -101,7 +99,8 @@ const TodoTaskItem: React.FC<TodoTaskItemProps> = ({
   data,
   viewConfig,
   onMint,
-  onRefreshTask,
+  onVerifyTask,
+  onVerifyAction,
   onTwitter,
   onDiscord,
   onFollowCommunity,
@@ -244,9 +243,9 @@ const TodoTaskItem: React.FC<TodoTaskItemProps> = ({
       navginate(`/${projectSlug}/${id}`)
     }
   }
-  const onRefreshClick = () => {
-    if (onRefreshTask) {
-      onRefreshTask(data)
+  const onVerifyTaskClick = () => {
+    if (onVerifyTask) {
+      onVerifyTask(data)
     }
   }
   return (
@@ -274,8 +273,9 @@ const TodoTaskItem: React.FC<TodoTaskItemProps> = ({
             displayVerify={displayRefresh}
             loadingVerify={loadingRefresh}
             disabledVerify={disabledRefresh}
-            onVerifyActions={onRefreshClick}
+            onVerifyActions={onVerifyTaskClick}
             verifyingActions={verifyingActions}
+            onVerifyAction={onVerifyAction}
           ></TaskActionList>
         </TaskActionsBox>
       )}

--- a/apps/collector-page/src/components/business/task/TodoTaskList.tsx
+++ b/apps/collector-page/src/components/business/task/TodoTaskList.tsx
@@ -2,7 +2,7 @@
  * @Author: shixuewen friendlysxw@163.com
  * @Date: 2022-07-13 16:25:14
  * @LastEditors: shixuewen friendlysxw@163.com
- * @LastEditTime: 2022-08-16 16:25:29
+ * @LastEditTime: 2022-08-22 19:13:46
  * @Description: file description
  */
 import React from 'react'
@@ -63,7 +63,8 @@ const TodoTaskList: React.FC<TodoTaskListProps> = ({
   loadingMsg = 'loading...',
   emptyMsg,
   onMint,
-  onRefreshTask,
+  onVerifyTask,
+  onVerifyAction,
   onTwitter,
   onDiscord,
   onFollowCommunity,
@@ -89,7 +90,8 @@ const TodoTaskList: React.FC<TodoTaskListProps> = ({
               data={item.data}
               viewConfig={item.viewConfig}
               onMint={onMint}
-              onRefreshTask={onRefreshTask}
+              onVerifyTask={onVerifyTask}
+              onVerifyAction={onVerifyAction}
               onDiscord={onDiscord}
               onTwitter={onTwitter}
               onFollowCommunity={onFollowCommunity}

--- a/apps/collector-page/src/features/task/taskDetailSlice.ts
+++ b/apps/collector-page/src/features/task/taskDetailSlice.ts
@@ -2,15 +2,16 @@
  * @Author: shixuewen friendlysxw@163.com
  * @Date: 2022-07-21 17:08:46
  * @LastEditors: shixuewen friendlysxw@163.com
- * @LastEditTime: 2022-08-12 18:25:34
+ * @LastEditTime: 2022-08-23 11:44:16
  * @Description: file description
  */
-import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { fetchDetail, createTask as createTaskApi } from '../../services/api/task'
 import { RootState } from '../../store/store'
 import { AsyncRequestStatus } from '../../types'
-import { TaskDetailResponse } from '../../types/api'
+import { TaskDetailResponse, TodoTaskActionItem } from '../../types/api'
 import { State as CreateTaskState } from '../../components/business/task/create/state'
+import { getTaskEntityForUpdateActionAfter } from '../../utils/task'
 
 export type TaskDetailEntity = TaskDetailResponse
 type TaskState = {
@@ -64,6 +65,13 @@ export const taskDetailSlice = createSlice({
     updateTaskDetail: (state, action) => {
       state.data = { ...state.data, ...action.payload }
     },
+    updateTaskDetailAction: (state, action: PayloadAction<TodoTaskActionItem>) => {
+      if (state.data) {
+        const task = state.data
+        const newTask = getTaskEntityForUpdateActionAfter(task, action.payload) as TaskDetailEntity
+        state.data = { ...newTask }
+      }
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -109,5 +117,5 @@ export const taskDetailSlice = createSlice({
 
 const { actions, reducer } = taskDetailSlice
 export const selectTaskDetail = (state: RootState) => state.taskDetail
-export const { updateTaskDetail } = actions
+export const { updateTaskDetail, updateTaskDetailAction } = actions
 export default reducer

--- a/apps/collector-page/src/features/user/taskHandlesSlice.ts
+++ b/apps/collector-page/src/features/user/taskHandlesSlice.ts
@@ -2,19 +2,35 @@
  * @Author: shixuewen friendlysxw@163.com
  * @Date: 2022-07-12 14:53:33
  * @LastEditors: shixuewen friendlysxw@163.com
- * @LastEditTime: 2022-08-17 10:28:53
+ * @LastEditTime: 2022-08-23 14:30:21
  * @Description: file description
  */
-import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+import { createAsyncThunk, createEntityAdapter, createSlice, EntityState } from '@reduxjs/toolkit'
 import { toast } from 'react-toastify'
-import { takeTask, verifyOneTask } from '../../services/api/task'
+import { takeTask as takeTaskRquest, verifyOneAction, verifyOneTask } from '../../services/api/task'
 import { RootState } from '../../store/store'
 import { AsyncRequestStatus } from '../../types'
-import { TaskAcceptedStatus, TaskTodoCompleteStatus } from '../../types/entities'
-import { fetchTaskDetail, updateTaskDetail } from '../task/taskDetailSlice'
-import { fetchTodoTasks } from './todoTasksSlice'
-// import { updateOne as updateOneForDashboardRecommendTasksSlice } from '../explore/recommendTasksSlice'
-// 每一种操作单独存储当前的数据状态
+import { Action, Task, TaskAcceptedStatus, TaskTodoCompleteStatus } from '../../types/entities'
+import { fetchTaskDetail, updateTaskDetail, updateTaskDetailAction } from '../task/taskDetailSlice'
+import { fetchTodoTasks, setOne as setOneForTodoTask, updateOneAction } from './todoTasksSlice'
+
+// create an execution queue for the verify task
+export type VerifyTaskQueueEntity = Task
+type VerifyTaskQueueState = EntityState<VerifyTaskQueueEntity>
+export const verifyTaskQueueEntity = createEntityAdapter<VerifyTaskQueueEntity>({
+  selectId: (item) => item.id,
+})
+const verifyTaskQueueState: VerifyTaskQueueState = verifyTaskQueueEntity.getInitialState()
+
+// create an execution queue for the verify action
+export type VerifyActionQueueEntity = Action
+type VerifyActionQueueState = EntityState<VerifyActionQueueEntity>
+export const verifyActionQueueEntity = createEntityAdapter<VerifyActionQueueEntity>({
+  selectId: (item) => item.id,
+})
+const verifyActionQueueState: VerifyActionQueueState = verifyActionQueueEntity.getInitialState()
+
+// unified management of task operations
 export type TaskHandle<T> = {
   params: T | null
   status: AsyncRequestStatus
@@ -23,28 +39,31 @@ export type TaskHandle<T> = {
 export type TakeTaskParams = {
   id: number
 }
-export type VerifyTaskParams = {
-  id: number
+export type UserTaskHandlesStateType = {
+  takeTask: TaskHandle<TakeTaskParams>
+  verifyTask: TaskHandle<Task>
+  verifyTaskQueue: VerifyTaskQueueState
+  verifyAction: TaskHandle<Action>
+  verifyActionQueue: VerifyActionQueueState
 }
+// init data
 const initTaskHandlestate = {
   params: null,
   status: AsyncRequestStatus.IDLE,
   errorMsg: '',
 }
-// 将操作集合到一起，统一管理
-export type UserTaskHandlesStateType = {
-  take: TaskHandle<TakeTaskParams>
-  verify: TaskHandle<VerifyTaskParams>
-}
 const initUserTaskHandlesState: UserTaskHandlesStateType = {
-  take: initTaskHandlestate,
-  verify: initTaskHandlestate,
+  takeTask: initTaskHandlestate,
+  verifyTask: initTaskHandlestate,
+  verifyTaskQueue: verifyTaskQueueState,
+  verifyAction: initTaskHandlestate,
+  verifyActionQueue: verifyActionQueueState,
 }
 
 // take task
-export const take = createAsyncThunk('user/taskHandles/take', async (params: TakeTaskParams, { dispatch }) => {
+export const takeTask = createAsyncThunk('user/taskHandles/takeTask', async (params: TakeTaskParams, { dispatch }) => {
   try {
-    const resp = await takeTask(params)
+    const resp = await takeTaskRquest(params)
     if (resp.data.code === 0) {
       const updateTask = { id: params.id, acceptedStatus: TaskAcceptedStatus.DONE, status: TaskTodoCompleteStatus.TODO }
       dispatch(updateTaskDetail(updateTask))
@@ -60,71 +79,164 @@ export const take = createAsyncThunk('user/taskHandles/take', async (params: Tak
 })
 
 // verify task
-export const verify = createAsyncThunk('user/taskHandles/verify', async (params: VerifyTaskParams, { dispatch }) => {
-  try {
-    const resp = await verifyOneTask(params)
-    if (resp.data.code === 0 && resp.data.data) {
-      dispatch(updateTaskDetail(resp.data.data))
-      dispatch(fetchTodoTasks())
-    } else {
-      throw new Error(resp.data.msg)
+export const verifyTask = createAsyncThunk(
+  'user/taskHandles/verifyTask',
+  async (task: Task, { dispatch }) => {
+    const { id } = task
+    try {
+      dispatch(addOneVerifyTaskQueue(task))
+      const resp = await verifyOneTask({ id })
+      if (resp.data.code === 0 && resp.data.data) {
+        dispatch(updateTaskDetail(resp.data.data))
+        dispatch(setOneForTodoTask(resp.data.data))
+      } else {
+        throw new Error(resp.data.msg)
+      }
+    } catch (error) {
+      throw error
+    } finally {
+      dispatch(removeOneVerifyTaskQueue(id))
     }
-  } catch (error) {
-    throw error
-  }
-})
+  },
+  {
+    condition: (task: Task, { getState }) => {
+      const state = getState() as RootState
+      const { selectById } = verifyTaskQueueEntity.getSelectors()
+      const item = selectById(state.userTaskHandles.verifyTaskQueue, task.id)
+      // 如果此 task 正在 verify task 的队列中则阻止新的verify请求
+      return !item
+    },
+  },
+)
+
+// verify action
+export const verifyAction = createAsyncThunk(
+  'user/taskHandles/verifyAction',
+  async (action: Action, { dispatch }) => {
+    const { id, taskId } = action
+    try {
+      dispatch(addOneVerifyActionQueue(action))
+      const resp = await verifyOneAction({ id, taskId })
+      if (resp.data.code === 0 && resp.data.data) {
+        dispatch(updateTaskDetailAction(resp.data.data))
+        dispatch(updateOneAction(resp.data.data))
+      } else {
+        throw new Error(resp.data.msg)
+      }
+    } catch (error) {
+      throw error
+    } finally {
+      dispatch(removeOneVerifyActionQueue(id))
+    }
+  },
+  {
+    condition: (action: Action, { getState }) => {
+      const state = getState() as RootState
+      const { selectById } = verifyActionQueueEntity.getSelectors()
+      const item = selectById(state.userTaskHandles.verifyActionQueue, action.id)
+      // 如果此 action 正在 verify action 的队列中则阻止新的verify请求
+      return !item
+    },
+  },
+)
+
 export const userTaskHandlesSlice = createSlice({
   name: 'TaskHandles',
   initialState: initUserTaskHandlesState,
-  reducers: {},
+  reducers: {
+    addOneVerifyTaskQueue: (state, action) => {
+      verifyTaskQueueEntity.addOne(state.verifyTaskQueue, action.payload)
+    },
+    removeOneVerifyTaskQueue: (state, action) => {
+      verifyTaskQueueEntity.removeOne(state.verifyTaskQueue, action.payload)
+    },
+    addOneVerifyActionQueue: (state, action) => {
+      verifyActionQueueEntity.addOne(state.verifyActionQueue, action.payload)
+    },
+    removeOneVerifyActionQueue: (state, action) => {
+      verifyActionQueueEntity.removeOne(state.verifyActionQueue, action.payload)
+    },
+  },
   extraReducers: (builder) => {
     builder
-      .addCase(take.pending, (state, action) => {
-        console.log('take pending', action)
-        state.take.params = action.meta.arg
-        state.take.status = AsyncRequestStatus.PENDING
-        state.take.errorMsg = ''
+      .addCase(takeTask.pending, (state, action) => {
+        console.log('takeTask pending', action)
+        state.takeTask.params = action.meta.arg
+        state.takeTask.status = AsyncRequestStatus.PENDING
+        state.takeTask.errorMsg = ''
       })
-      .addCase(take.fulfilled, (state, action) => {
-        console.log('take fulfilled', action)
-        state.take.params = null
-        state.take.status = AsyncRequestStatus.FULFILLED
-        state.take.errorMsg = ''
+      .addCase(takeTask.fulfilled, (state, action) => {
+        console.log('takeTask fulfilled', action)
+        state.takeTask.params = null
+        state.takeTask.status = AsyncRequestStatus.FULFILLED
+        state.takeTask.errorMsg = ''
         toast.success('take task success')
       })
-      .addCase(take.rejected, (state, action) => {
-        console.log('take rejected', action)
-        state.take.params = null
-        state.take.status = AsyncRequestStatus.REJECTED
-        state.take.errorMsg = action.error.message || ''
+      .addCase(takeTask.rejected, (state, action) => {
+        console.log('takeTask rejected', action)
+        state.takeTask.params = null
+        state.takeTask.status = AsyncRequestStatus.REJECTED
+        state.takeTask.errorMsg = action.error.message || ''
         toast.error(action.error.message)
       })
-      .addCase(verify.pending, (state, action) => {
-        console.log('verify pending', action)
-        state.verify.params = action.meta.arg
-        state.verify.status = AsyncRequestStatus.PENDING
-        state.verify.errorMsg = ''
+      .addCase(verifyTask.pending, (state, action) => {
+        console.log('verifyTask pending', action)
+        state.verifyTask.params = action.meta.arg
+        state.verifyTask.status = AsyncRequestStatus.PENDING
+        state.verifyTask.errorMsg = ''
       })
-      .addCase(verify.fulfilled, (state, action) => {
-        console.log('verify fulfilled', action)
-        state.verify.params = null
-        state.verify.status = AsyncRequestStatus.FULFILLED
-        state.verify.errorMsg = ''
-        toast.success('verify task success')
+      .addCase(verifyTask.fulfilled, (state, action) => {
+        console.log('verifyTask fulfilled', action)
+        state.verifyTask.params = null
+        state.verifyTask.status = AsyncRequestStatus.FULFILLED
+        state.verifyTask.errorMsg = ''
+        toast.success('verifyTask task success')
       })
-      .addCase(verify.rejected, (state, action) => {
-        console.log('verify rejected', action)
-        state.verify.params = null
-        state.verify.status = AsyncRequestStatus.REJECTED
-        state.verify.errorMsg = action.error.message || ''
+      .addCase(verifyTask.rejected, (state, action) => {
+        console.log('verifyTask rejected', action)
+        state.verifyTask.params = null
+        state.verifyTask.status = AsyncRequestStatus.REJECTED
+        state.verifyTask.errorMsg = action.error.message || ''
+        toast.error(action.error.message)
+      })
+      .addCase(verifyAction.pending, (state, action) => {
+        console.log('verifyAction pending', action)
+        state.verifyAction.params = action.meta.arg
+        state.verifyAction.status = AsyncRequestStatus.PENDING
+        state.verifyAction.errorMsg = ''
+      })
+      .addCase(verifyAction.fulfilled, (state, action) => {
+        console.log('verifyAction fulfilled', action)
+        state.verifyAction.params = null
+        state.verifyAction.status = AsyncRequestStatus.FULFILLED
+        state.verifyAction.errorMsg = ''
+        toast.success('verify action success')
+      })
+      .addCase(verifyAction.rejected, (state, action) => {
+        console.log('verifyAction rejected', action)
+        state.verifyAction.params = null
+        state.verifyAction.status = AsyncRequestStatus.REJECTED
+        state.verifyAction.errorMsg = action.error.message || ''
         toast.error(action.error.message)
       })
   },
 })
 
-export const selectTake = (state: RootState) => state.userTaskHandles.take
 export const selectUserTaskHandlesState = (state: RootState) => state.userTaskHandles
 
+export const {
+  selectAll: selectAllVerifyTaskQueue,
+  selectIds: selectIdsVerifyTaskQueue,
+  selectById: selectByIdVerifyTaskQueue,
+} = verifyTaskQueueEntity.getSelectors((state: RootState) => state.userTaskHandles.verifyTaskQueue)
+
+export const {
+  selectAll: selectAllVerifyActionQueue,
+  selectIds: selectIdsVerifyActionQueue,
+  selectById: selectByIdVerifyActionQueue,
+} = verifyActionQueueEntity.getSelectors((state: RootState) => state.userTaskHandles.verifyActionQueue)
+
 const { actions, reducer } = userTaskHandlesSlice
+const { addOneVerifyTaskQueue, removeOneVerifyTaskQueue, addOneVerifyActionQueue, removeOneVerifyActionQueue } = actions
 
 export default reducer

--- a/apps/collector-page/src/features/user/taskHandlesSlice.ts
+++ b/apps/collector-page/src/features/user/taskHandlesSlice.ts
@@ -2,7 +2,7 @@
  * @Author: shixuewen friendlysxw@163.com
  * @Date: 2022-07-12 14:53:33
  * @LastEditors: shixuewen friendlysxw@163.com
- * @LastEditTime: 2022-08-23 14:30:21
+ * @LastEditTime: 2022-08-23 14:52:40
  * @Description: file description
  */
 import { createAsyncThunk, createEntityAdapter, createSlice, EntityState } from '@reduxjs/toolkit'
@@ -12,6 +12,7 @@ import { RootState } from '../../store/store'
 import { AsyncRequestStatus } from '../../types'
 import { Action, Task, TaskAcceptedStatus, TaskTodoCompleteStatus } from '../../types/entities'
 import { fetchTaskDetail, updateTaskDetail, updateTaskDetailAction } from '../task/taskDetailSlice'
+import { fetchFollowedCommunities } from './followedCommunitiesSlice'
 import { fetchTodoTasks, setOne as setOneForTodoTask, updateOneAction } from './todoTasksSlice'
 
 // create an execution queue for the verify task
@@ -69,6 +70,7 @@ export const takeTask = createAsyncThunk('user/taskHandles/takeTask', async (par
       dispatch(updateTaskDetail(updateTask))
       dispatch(fetchTaskDetail(params.id))
       dispatch(fetchTodoTasks())
+      dispatch(fetchFollowedCommunities())
     } else {
       throw new Error(resp.data.msg)
     }

--- a/apps/collector-page/src/services/api/task.ts
+++ b/apps/collector-page/src/services/api/task.ts
@@ -2,14 +2,14 @@
  * @Author: shixuewen friendlysxw@163.com
  * @Date: 2022-07-12 15:36:56
  * @LastEditors: shixuewen friendlysxw@163.com
- * @LastEditTime: 2022-08-11 16:02:52
+ * @LastEditTime: 2022-08-22 18:11:34
  * @Description: file description
  */
 import { AxiosPromise } from 'axios'
 import { loadRefInfo, RefType } from '../../container/Ref'
 import request from '../../request/axios'
 import { ApiResp } from '../../types'
-import { TaskDetailResponse, TodoTaskItem, TodoTaskResponse } from '../../types/api'
+import { TaskDetailResponse, TodoTaskActionItem, TodoTaskItem, TodoTaskResponse } from '../../types/api'
 import { State as CreateTaskState } from '../../components/business/task/create/state'
 import { useGAEvent } from '../../hooks/useGoogleAnalytics'
 
@@ -17,6 +17,7 @@ const TASK_CATALOG_GA = 'TASK'
 enum TaskActionGA {
   TAKE_TASK = 'TAKE_TASK',
   VERIFY_ACTIONS = 'VERIFY_ACTIONS',
+  VERIFY_ONE_ACTION = 'VERIFY_ONE_ACTION',
 }
 
 /** 接任务 */
@@ -71,6 +72,24 @@ export function verifyOneTask(params: VerifyOneTaskParams): AxiosPromise<ApiResp
   gaEvent(TaskActionGA.VERIFY_ACTIONS, id)
   return request({
     url: `/tasks/${id}/verification`,
+    method: 'post',
+    headers: {
+      needToken: true,
+    },
+  })
+}
+
+/** 对单个action进行验证 */
+export type VerifyOneActionParams = {
+  id: number
+  taskId: number
+}
+export function verifyOneAction(params: VerifyOneActionParams): AxiosPromise<ApiResp<TodoTaskActionItem>> {
+  const { taskId, id } = params
+  const gaEvent = useGAEvent(TASK_CATALOG_GA)
+  gaEvent(TaskActionGA.VERIFY_ONE_ACTION, id)
+  return request({
+    url: `/tasks/${taskId}/actions/${id}/verification`,
     method: 'post',
     headers: {
       needToken: true,

--- a/apps/collector-page/src/store/store.ts
+++ b/apps/collector-page/src/store/store.ts
@@ -2,7 +2,7 @@
  * @Author: shixuewen friendlysxw@163.com
  * @Date: 2022-07-01 15:09:50
  * @LastEditors: shixuewen friendlysxw@163.com
- * @LastEditTime: 2022-08-01 16:26:46
+ * @LastEditTime: 2022-08-23 13:46:39
  * @Description: store
  */
 import { configureStore } from '@reduxjs/toolkit'

--- a/apps/collector-page/src/utils/task.ts
+++ b/apps/collector-page/src/utils/task.ts
@@ -2,10 +2,13 @@
  * @Author: shixuewen friendlysxw@163.com
  * @Date: 2022-08-15 15:37:28
  * @LastEditors: shixuewen friendlysxw@163.com
- * @LastEditTime: 2022-08-15 15:40:48
+ * @LastEditTime: 2022-08-23 12:03:03
  * @Description: file description
  */
-import { RewardType } from '../types/entities'
+import { TaskDetailEntity } from '../features/task/taskDetailSlice'
+import { TodoTaskItemForEntity } from '../features/user/todoTasksSlice'
+import { TaskDetailResponse, TodoTaskActionItem, TodoTaskItem, UserActionStatus } from '../types/api'
+import { RewardType, TaskTodoCompleteStatus } from '../types/entities'
 
 export const getTaskRewardTypeLabel = (reward?: { type: RewardType; raffled: boolean }) => {
   let rewardTypeLabel = 'Unknown Reward Type'
@@ -20,4 +23,21 @@ export const getTaskRewardTypeLabel = (reward?: { type: RewardType; raffled: boo
     }
   }
   return rewardTypeLabel
+}
+
+type TaskEntityType = TodoTaskItemForEntity | TaskDetailEntity
+export const getTaskEntityForUpdateActionAfter = (task: TaskEntityType, action: TodoTaskActionItem): TaskEntityType => {
+  const { id } = action
+  const actions = task.actions.map((item) => (item.id === id ? action : item))
+  const taskIsCompleted = actions.every((item) => item.status === UserActionStatus.DONE)
+  let status = task.status
+  if (taskIsCompleted) {
+    status = TaskTodoCompleteStatus.COMPLETED
+  } else {
+    const taskIsInProgress = actions.some((item) => item.status === UserActionStatus.DONE)
+    if (taskIsInProgress) {
+      status = TaskTodoCompleteStatus.IN_PRGRESS
+    }
+  }
+  return { ...task, status, actions }
 }


### PR DESCRIPTION
1. 添加 verify one action 的逻辑。
2. 优化之前的 verify action loading状态逻辑。

关于数据的更新：

1. take task 再异步获取一次followedCommunites。
2. verify one action后同步更新当前action对应的task的status和actions值 。（应用于 taskDetail、todoTasks）

问题：
verify on action后在前端更新task status，目前只将status 更新为可能的两个值 IN_PROGRESS 或 COMPLETE, 有可能会直接变成WON 或其它吗？
